### PR TITLE
Add code marker

### DIFF
--- a/rcirc-notify.el
+++ b/rcirc-notify.el
@@ -76,6 +76,8 @@
 ;; /ai:http://www.emacswiki.org/pics/static/CarbonEmacsPackageIcon.png \
 ;; /a:Emacs /r:IRC /n:IRC foo
 
+;;; Code:
+
 (require 'rcirc)
 (require 'cl) ;; needed for 'some'
 


### PR DESCRIPTION
This would fix the marmalade package, where currently all the code of
this file is considered commentary.
